### PR TITLE
feat: add READ_PHONE_STATE permission handling for incoming calls

### DIFF
--- a/android/src/main/kotlin/com/twilio/twilio_voice/AnswerCallTrampolineActivity.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/AnswerCallTrampolineActivity.kt
@@ -45,6 +45,12 @@ class AnswerCallTrampolineActivity : AppCompatActivity() {
         private const val TAG = "AnswerTrampoline"
         private const val REQUEST_RECORD_AUDIO_PERMISSION = 201
 
+        /** Permissions required to answer a call */
+        private val REQUIRED_CALL_PERMISSIONS = arrayOf(
+            Manifest.permission.RECORD_AUDIO,
+            Manifest.permission.READ_PHONE_STATE,
+        )
+
         const val EXTRA_CALL_SID = "extra_call_sid"
         const val EXTRA_CALL_INVITE = "extra_call_invite"
         const val EXTRA_CALLER_NAME = "extra_caller_name"
@@ -73,33 +79,74 @@ class AnswerCallTrampolineActivity : AppCompatActivity() {
             return
         }
 
-        // Check RECORD_AUDIO permission BEFORE sending ACTION_ANSWER.
+        // Check RECORD_AUDIO & READ_PHONE_STATE permissions BEFORE sending ACTION_ANSWER.
         // This prevents the Twilio SDK from crashing when callInvite.accept()
         // is called without microphone access.
-        if (ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) {
-            Log.d(TAG, "onCreate: RECORD_AUDIO not granted — requesting permission")
-            // The permission dialog will appear over the notification/home screen.
-            // Since this activity is translucent, there's no black screen behind it.
-            ActivityCompat.requestPermissions(this, arrayOf(Manifest.permission.RECORD_AUDIO), REQUEST_RECORD_AUDIO_PERMISSION)
+        val missing = REQUIRED_CALL_PERMISSIONS.filter {
+            ContextCompat.checkSelfPermission(this, it) != PackageManager.PERMISSION_GRANTED
+        }
+        if (missing.isNotEmpty()) {
+            // Check for permanently denied permissions
+            val prefs = getSharedPreferences("easify_permissions", Context.MODE_PRIVATE)
+            val permanentlyDenied = missing.filter {
+                !ActivityCompat.shouldShowRequestPermissionRationale(this, it) &&
+                    prefs.getBoolean("requested_$it", false)
+            }
+            if (permanentlyDenied.size == missing.size) {
+                Log.d(TAG, "onCreate: All missing permissions permanently denied — opening settings")
+                openAppSettings()
+                finish()
+                return
+            }
+            // Track that we've requested these
+            prefs.edit().apply {
+                missing.forEach { putBoolean("requested_$it", true) }
+                apply()
+            }
+            Log.d(TAG, "onCreate: Missing permissions: $missing — requesting")
+            ActivityCompat.requestPermissions(this, missing.toTypedArray(), REQUEST_RECORD_AUDIO_PERMISSION)
             return  // Wait for onRequestPermissionsResult
         }
 
-        // Permission already granted — proceed immediately
-        Log.d(TAG, "onCreate: RECORD_AUDIO already granted — proceeding")
+        // Permissions already granted — proceed immediately
+        Log.d(TAG, "onCreate: All call permissions already granted — proceeding")
         proceedWithAnswer()
     }
 
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
         if (requestCode == REQUEST_RECORD_AUDIO_PERMISSION) {
-            if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                Log.d(TAG, "onRequestPermissionsResult: RECORD_AUDIO granted — proceeding with answer")
+            val allGranted = grantResults.isNotEmpty() && grantResults.all { it == PackageManager.PERMISSION_GRANTED }
+            if (allGranted) {
+                Log.d(TAG, "onRequestPermissionsResult: All call permissions granted — proceeding with answer")
                 proceedWithAnswer()
             } else {
-                Log.w(TAG, "onRequestPermissionsResult: RECORD_AUDIO denied — cannot answer call")
-                Toast.makeText(this, "Microphone permission is required to answer calls", Toast.LENGTH_LONG).show()
+                // Check if any permission is now permanently denied
+                val permanentlyDenied = permissions.filterIndexed { index, _ ->
+                    grantResults[index] != PackageManager.PERMISSION_GRANTED
+                }.filter { !ActivityCompat.shouldShowRequestPermissionRationale(this, it) }
+
+                if (permanentlyDenied.isNotEmpty()) {
+                    Log.d(TAG, "onRequestPermissionsResult: Permanently denied: $permanentlyDenied — opening settings")
+                    openAppSettings()
+                } else {
+                    Toast.makeText(this, "Microphone and Phone State permissions are required to answer calls", Toast.LENGTH_LONG).show()
+                }
                 finish()
             }
+        }
+    }
+
+    private fun openAppSettings() {
+        try {
+            val intent = Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                data = android.net.Uri.fromParts("package", packageName, null)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            startActivity(intent)
+            Toast.makeText(this, "Please enable the required permissions and try again", Toast.LENGTH_LONG).show()
+        } catch (e: Exception) {
+            Log.e(TAG, "openAppSettings: Failed to open settings", e)
         }
     }
 

--- a/android/src/main/kotlin/com/twilio/twilio_voice/CallWaitingSheetActivity.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/CallWaitingSheetActivity.kt
@@ -38,6 +38,12 @@ class CallWaitingSheetActivity : AppCompatActivity() {
         private const val TAG = "CallWaitingSheet"
         private const val REQUEST_RECORD_AUDIO = 200
 
+        /** Permissions required to answer a call */
+        private val REQUIRED_CALL_PERMISSIONS = arrayOf(
+            Manifest.permission.RECORD_AUDIO,
+            Manifest.permission.READ_PHONE_STATE,
+        )
+
         // Intent extras — same keys as IncomingCallActivity for consistency
         const val EXTRA_CALL_SID = "extra_call_sid"
         const val EXTRA_CALL_INVITE = "extra_call_invite"
@@ -263,29 +269,74 @@ class CallWaitingSheetActivity : AppCompatActivity() {
         finishAndRemoveTask()
     }
 
-    // ── Microphone permission ────────────────────────────────────────────────
+    // ── Call permissions (mic + phone state) ───────────────────────────────
 
     private fun ensureMicPermission(action: PendingAction): Boolean {
-        if (ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO)
-            == PackageManager.PERMISSION_GRANTED) return true
+        val missing = REQUIRED_CALL_PERMISSIONS.filter {
+            ContextCompat.checkSelfPermission(this, it) != PackageManager.PERMISSION_GRANTED
+        }
+        if (missing.isEmpty()) return true
+
+        // Check for permanently denied permissions
+        val prefs = getSharedPreferences("easify_permissions", Context.MODE_PRIVATE)
+        val permanentlyDenied = missing.filter {
+            !ActivityCompat.shouldShowRequestPermissionRationale(this, it) &&
+                prefs.getBoolean("requested_$it", false)
+        }
+        if (permanentlyDenied.size == missing.size) {
+            android.util.Log.d(TAG, "ensureMicPermission: All missing permissions permanently denied — opening settings")
+            openAppSettings()
+            return false
+        }
+
+        // Track that we've requested these
+        prefs.edit().apply {
+            missing.forEach { putBoolean("requested_$it", true) }
+            apply()
+        }
+
         pendingAction = action
-        ActivityCompat.requestPermissions(this, arrayOf(Manifest.permission.RECORD_AUDIO), REQUEST_RECORD_AUDIO)
+        ActivityCompat.requestPermissions(this, missing.toTypedArray(), REQUEST_RECORD_AUDIO)
         return false
     }
 
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
         if (requestCode == REQUEST_RECORD_AUDIO) {
-            if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+            val allGranted = grantResults.isNotEmpty() && grantResults.all { it == PackageManager.PERMISSION_GRANTED }
+            if (allGranted) {
                 when (pendingAction) {
                     PendingAction.HOLD_AND_ANSWER -> holdAndAnswer()
                     PendingAction.END_AND_ANSWER -> endAndAnswer()
                     PendingAction.NONE -> {}
                 }
             } else {
-                android.widget.Toast.makeText(this, "Microphone permission is required to answer calls", android.widget.Toast.LENGTH_LONG).show()
+                // Check if any permission is now permanently denied
+                val permanentlyDenied = permissions.filterIndexed { index, _ ->
+                    grantResults[index] != PackageManager.PERMISSION_GRANTED
+                }.filter { !ActivityCompat.shouldShowRequestPermissionRationale(this, it) }
+
+                if (permanentlyDenied.isNotEmpty()) {
+                    android.util.Log.d(TAG, "onRequestPermissionsResult: Permanently denied: $permanentlyDenied — opening settings")
+                    openAppSettings()
+                } else {
+                    android.widget.Toast.makeText(this, "Microphone and Phone State permissions are required to answer calls", android.widget.Toast.LENGTH_LONG).show()
+                }
             }
             pendingAction = PendingAction.NONE
+        }
+    }
+
+    private fun openAppSettings() {
+        try {
+            val intent = Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                data = android.net.Uri.fromParts("package", packageName, null)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            startActivity(intent)
+            android.widget.Toast.makeText(this, "Please enable the required permissions and try again", android.widget.Toast.LENGTH_LONG).show()
+        } catch (e: Exception) {
+            android.util.Log.e(TAG, "openAppSettings: Failed to open settings", e)
         }
     }
 

--- a/android/src/main/kotlin/com/twilio/twilio_voice/IncomingCallActivity.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/IncomingCallActivity.kt
@@ -86,6 +86,12 @@ class IncomingCallActivity : AppCompatActivity() {
         const val EXTRA_WAS_APP_IN_FOREGROUND = "EXTRA_WAS_APP_IN_FOREGROUND"
         private const val REQUEST_RECORD_AUDIO_PERMISSION = 200
 
+        /** Permissions required to answer a call */
+        private val REQUIRED_CALL_PERMISSIONS = arrayOf(
+            Manifest.permission.RECORD_AUDIO,
+            Manifest.permission.READ_PHONE_STATE,
+        )
+
         fun createIntent(context: Context, callInvite: CallInvite): Intent {
             return Intent(context, IncomingCallActivity::class.java).apply {
                 // Flags for lock screen incoming call display
@@ -763,16 +769,14 @@ class IncomingCallActivity : AppCompatActivity() {
         
         android.util.Log.d(TAG, "handleAnswerFromNotification: Extracted caller info - name: $callerName, number: $callerNumber, myNumber: $myNumber")
         
-        // Check for RECORD_AUDIO permission before answering
-        if (ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) {
-            android.util.Log.d(TAG, "handleAnswerFromNotification: Requesting RECORD_AUDIO permission")
+        // Check for RECORD_AUDIO & READ_PHONE_STATE permissions before answering
+        if (!ensureCallPermissions("handleAnswerFromNotification")) {
             // Reset callHandled so proceedWithAnswer can set it again
             callHandled = false
-            ActivityCompat.requestPermissions(this, arrayOf(Manifest.permission.RECORD_AUDIO), REQUEST_RECORD_AUDIO_PERMISSION)
             return
         }
         
-        android.util.Log.d(TAG, "handleAnswerFromNotification: RECORD_AUDIO permission GRANTED - proceeding to answer call")
+        android.util.Log.d(TAG, "handleAnswerFromNotification: Call permissions GRANTED - proceeding to answer call")
         
         if (sid != null) {
             android.util.Log.d(TAG, "handleAnswerFromNotification: Answering call with callSid: $sid, hasCallInvite: ${invite != null}")
@@ -1418,6 +1422,73 @@ class IncomingCallActivity : AppCompatActivity() {
         bitmap.setPixels(pix, 0, w, 0, 0, w, h)
         return bitmap
     }
+
+    /**
+     * Returns true if all [REQUIRED_CALL_PERMISSIONS] are granted.
+     * If any are missing, requests them (or opens app settings if permanently denied)
+     * and returns false.
+     */
+    private fun ensureCallPermissions(callerTag: String): Boolean {
+        val missing = REQUIRED_CALL_PERMISSIONS.filter {
+            ContextCompat.checkSelfPermission(this, it) != PackageManager.PERMISSION_GRANTED
+        }
+        if (missing.isEmpty()) return true
+
+        // Check if any missing permission is permanently denied ("Don't ask again").
+        // shouldShowRequestPermissionRationale returns false if:
+        //   1. Permission was never requested (first time), OR
+        //   2. User chose "Don't ask again"
+        // We can distinguish by checking if we can still request (the system dialog will appear).
+        // If ALL missing permissions return false for rationale AND have been requested before,
+        // the system won't show a dialog — we must redirect to app settings.
+        val permanentlyDenied = missing.filter {
+            !ActivityCompat.shouldShowRequestPermissionRationale(this, it)
+        }
+
+        // If some can still be requested via dialog, request them all.
+        // The system will only show dialogs for the ones that aren't permanently denied,
+        // and immediately return DENIED for permanently denied ones.
+        // However, if ALL missing are permanently denied, skip the useless request
+        // and go straight to settings.
+        if (permanentlyDenied.size == missing.size && permanentlyDenied.isNotEmpty()) {
+            // Check if this is truly "permanently denied" vs "never asked".
+            // On first request, shouldShowRequestPermissionRationale also returns false.
+            // Use SharedPreferences to track if we've asked before.
+            val prefs = getSharedPreferences("easify_permissions", Context.MODE_PRIVATE)
+            val allPreviouslyRequested = permanentlyDenied.all {
+                prefs.getBoolean("requested_$it", false)
+            }
+            if (allPreviouslyRequested) {
+                android.util.Log.d(TAG, "$callerTag: All missing permissions permanently denied, opening app settings: $missing")
+                openAppSettings()
+                return false
+            }
+        }
+
+        // Mark these permissions as having been requested
+        val prefs = getSharedPreferences("easify_permissions", Context.MODE_PRIVATE)
+        prefs.edit().apply {
+            missing.forEach { putBoolean("requested_$it", true) }
+            apply()
+        }
+
+        android.util.Log.d(TAG, "$callerTag: Requesting missing permissions: $missing")
+        ActivityCompat.requestPermissions(this, missing.toTypedArray(), REQUEST_RECORD_AUDIO_PERMISSION)
+        return false
+    }
+
+    private fun openAppSettings() {
+        try {
+            val intent = Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                data = android.net.Uri.fromParts("package", packageName, null)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            startActivity(intent)
+            android.widget.Toast.makeText(this, "Please enable the required permissions and try again", android.widget.Toast.LENGTH_LONG).show()
+        } catch (e: Exception) {
+            android.util.Log.e(TAG, "openAppSettings: Failed to open settings", e)
+        }
+    }
     
     private fun answerCallWithHold() {
         stopRinging()
@@ -1427,11 +1498,7 @@ class IncomingCallActivity : AppCompatActivity() {
             return
         }
         
-        if (ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) {
-            android.util.Log.d(TAG, "answerCallWithHold: Requesting RECORD_AUDIO permission")
-            ActivityCompat.requestPermissions(this, arrayOf(Manifest.permission.RECORD_AUDIO), REQUEST_RECORD_AUDIO_PERMISSION)
-            return
-        }
+        if (!ensureCallPermissions("answerCallWithHold")) return
         
         callHandled = true
         // CRITICAL: Cancel all pending MIUI postDelayed callbacks BEFORE finishing.
@@ -1469,11 +1536,7 @@ class IncomingCallActivity : AppCompatActivity() {
             return
         }
         
-        if (ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) {
-            android.util.Log.d(TAG, "answerCallWithEndFirst: Requesting RECORD_AUDIO permission")
-            ActivityCompat.requestPermissions(this, arrayOf(Manifest.permission.RECORD_AUDIO), REQUEST_RECORD_AUDIO_PERMISSION)
-            return
-        }
+        if (!ensureCallPermissions("answerCallWithEndFirst")) return
         
         callHandled = true
         cancelPendingCallbacks()
@@ -1511,12 +1574,8 @@ class IncomingCallActivity : AppCompatActivity() {
             return
         }
         
-        // Check for RECORD_AUDIO permission before answering
-        if (ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) {
-            android.util.Log.d(TAG, "answerCall: Requesting RECORD_AUDIO permission")
-            ActivityCompat.requestPermissions(this, arrayOf(Manifest.permission.RECORD_AUDIO), REQUEST_RECORD_AUDIO_PERMISSION)
-            return
-        }
+        // Check for RECORD_AUDIO & READ_PHONE_STATE permissions before answering
+        if (!ensureCallPermissions("answerCall")) return
         
         proceedWithAnswer()
     }
@@ -1673,13 +1732,23 @@ class IncomingCallActivity : AppCompatActivity() {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
         when (requestCode) {
             REQUEST_RECORD_AUDIO_PERMISSION -> {
-                if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    android.util.Log.d(TAG, "onRequestPermissionsResult: RECORD_AUDIO permission granted, proceeding with answer")
+                val allGranted = grantResults.isNotEmpty() && grantResults.all { it == PackageManager.PERMISSION_GRANTED }
+                if (allGranted) {
+                    android.util.Log.d(TAG, "onRequestPermissionsResult: All call permissions granted, proceeding with answer")
                     proceedWithAnswer()
                 } else {
-                    android.util.Log.w(TAG, "onRequestPermissionsResult: RECORD_AUDIO permission denied, cannot answer call")
-                    // Show toast or message that permission is required
-                    android.widget.Toast.makeText(this, "Microphone permission is required to answer calls", android.widget.Toast.LENGTH_LONG).show()
+                    android.util.Log.w(TAG, "onRequestPermissionsResult: Call permissions denied")
+                    // Check if any permission is now permanently denied
+                    val permanentlyDenied = permissions.filterIndexed { index, _ ->
+                        grantResults[index] != PackageManager.PERMISSION_GRANTED
+                    }.filter { !ActivityCompat.shouldShowRequestPermissionRationale(this, it) }
+
+                    if (permanentlyDenied.isNotEmpty()) {
+                        android.util.Log.d(TAG, "onRequestPermissionsResult: Permanently denied permissions: $permanentlyDenied — opening settings")
+                        openAppSettings()
+                    } else {
+                        android.widget.Toast.makeText(this, "Microphone and Phone State permissions are required to answer calls", android.widget.Toast.LENGTH_LONG).show()
+                    }
                 }
             }
         }

--- a/android/src/main/kotlin/com/twilio/twilio_voice/TwilioVoicePlugin.kt
+++ b/android/src/main/kotlin/com/twilio/twilio_voice/TwilioVoicePlugin.kt
@@ -1226,14 +1226,17 @@ class TwilioVoicePlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamH
             }
 
             TVMethodChannels.HAS_READ_PHONE_STATE_PERMISSION -> {
-                // No longer required - always return true
-                result.success(true)
+                result.success(checkReadPhoneStatePermission())
             }
 
             TVMethodChannels.REQUEST_READ_PHONE_STATE_PERMISSION -> {
-                // No longer required - skip and return success
-                logEvent("requestingReadPhoneStatePermission - skipped, not required")
-                result.success(true)
+                if (!checkReadPhoneStatePermission()) {
+                    requestPermissionForPhoneState { granted ->
+                        result.success(granted)
+                    }
+                } else {
+                    result.success(true)
+                }
             }
 
             TVMethodChannels.HAS_CALL_PHONE_PERMISSION -> {


### PR DESCRIPTION
## Summary
Adds READ_PHONE_STATE permission to the incoming call answer flow alongside RECORD_AUDIO.

## Changes

### TwilioVoicePlugin.kt
- Fixed `HAS_READ_PHONE_STATE_PERMISSION` handler to call actual `checkReadPhoneStatePermission()` instead of always returning true
- Fixed `REQUEST_READ_PHONE_STATE_PERMISSION` handler to call actual `requestPermissionForPhoneState()` instead of always returning true

### IncomingCallActivity.kt
- Added `READ_PHONE_STATE` to `REQUIRED_CALL_PERMISSIONS` array
- Added `ensureCallPermissions()` helper with SharedPreferences tracking for permanently denied detection
- Added `openAppSettings()` helper for permanently denied permissions
- Updated `answerCall()`, `answerCallWithHold()`, `answerCallWithEndFirst()`, `handleAnswerFromNotification()` to check both permissions
- Updated `onRequestPermissionsResult()` to handle permanently denied → app settings redirect

### AnswerCallTrampolineActivity.kt
- Added `READ_PHONE_STATE` to `REQUIRED_CALL_PERMISSIONS` array
- Added permanently denied detection with SharedPreferences
- Added `openAppSettings()` helper

### CallWaitingSheetActivity.kt
- Added `READ_PHONE_STATE` to `REQUIRED_CALL_PERMISSIONS` array
- Applied same permanently denied handling pattern